### PR TITLE
feat: optional zone param, for when the domain is within the zone

### DIFF
--- a/API.md
+++ b/API.md
@@ -153,6 +153,7 @@ const hugoDeployProps: HugoDeployProps = { ... }
 | <code><a href="#cdk-hugo-deploy.HugoDeployProps.property.domainName">domainName</a></code> | <code>string</code> | Domain name of the site deploying to. |
 | <code><a href="#cdk-hugo-deploy.HugoDeployProps.property.publicDir">publicDir</a></code> | <code>string</code> | Path to Hugo public directory, which is generated after running the `hugo` command. |
 | <code><a href="#cdk-hugo-deploy.HugoDeployProps.property.region">region</a></code> | <code>string</code> | Region deploying to. |
+| <code><a href="#cdk-hugo-deploy.HugoDeployProps.property.zone">zone</a></code> | <code>aws-cdk-lib.aws_route53.HostedZone</code> | Zone the Domain Name is created in. |
 
 ---
 
@@ -194,6 +195,18 @@ public readonly region: string;
 - *Default:* us-east-1
 
 Region deploying to.
+
+---
+
+##### `zone`<sup>Optional</sup> <a name="zone" id="cdk-hugo-deploy.HugoDeployProps.property.zone"></a>
+
+```typescript
+public readonly zone: HostedZone;
+```
+
+- *Type:* aws-cdk-lib.aws_route53.HostedZone
+
+Zone the Domain Name is created in.
 
 ---
 

--- a/src/hugoDeploy.ts
+++ b/src/hugoDeploy.ts
@@ -32,6 +32,11 @@ export interface HugoDeployProps {
   readonly domainName: string;
 
   /**
+   * Zone the Domain Name is created in
+   */
+  readonly zone?: HostedZone;
+
+  /**
    * Region deploying to
    *
    * @default - us-east-1
@@ -54,9 +59,11 @@ export class HugoDeploy extends Construct {
     const bucket = new Bucket(this, 'WebsiteBucket', {
       publicReadAccess: false,
     });
-    const zone = HostedZone.fromLookup(this, 'HostedZone', {
-      domainName: this.domainName,
-    });
+    const zone = props.zone
+      ? props.zone
+      : HostedZone.fromLookup(this, 'HostedZone', {
+          domainName: this.domainName,
+        });
     const certificate = new DnsValidatedCertificate(this, 'Certificate', {
       hostedZone: zone,
       domainName: this.domainName,


### PR DESCRIPTION
I want my hugo site to be a in my zone, but not its root.  This allows for me to look the zone up before the call to hugoDeploy so that the domain is created within the zone I specify even when it is not the root of that zone.  for example hugo might be deploying www.<name>.org instead of deploying <name>.org.  